### PR TITLE
Fixed Leader-board page bug

### DIFF
--- a/app/views/users/leaderboard.haml
+++ b/app/views/users/leaderboard.haml
@@ -25,29 +25,30 @@
                     %tbody
                         - first_ranking = @rankings.first
                         - count = (@rankings.current_page - 1) * @per_page + 1
-                        - ordinal = first_ranking.ordinal
-                        - rating = first_ranking.value.rating
-                        - @rankings.each do |ranking|
-                            - if ranking.value.rating + Ranking::RATING_ERROR < rating
-                                - rating = ranking.value.rating
-                                - ordinal = count
-                            - count += 1
-                            %tr
-                                %td
-                                    = ordinal
-                                %td
-                                    %strong= ranking.formatted_rating
-                                %td
-                                    = ranking.value.matches
-                                %td
-                                    = ranking.value.win_loss_ratio.round(3)
-                                %td
-                                    = ranking.value.wins
-                                %td
-                                    = ranking.value.losses
-                                %td
-                                    = ranking.value.forfeits
-                                %td
-                                    = avatar_for(ranking.value.user, 16, glow: true)
-                                    = link_to_user(ranking.value.user)
+                        - if first_ranking.present?
+                            - ordinal = first_ranking.ordinal
+                            - rating = first_ranking.value.rating
+                            - @rankings.each do |ranking|
+                                - if ranking.value.rating + Ranking::RATING_ERROR < rating
+                                    - rating = ranking.value.rating
+                                    - ordinal = count
+                                - count += 1
+                                %tr
+                                    %td
+                                        = ordinal
+                                    %td
+                                        %strong= ranking.formatted_rating
+                                    %td
+                                        = ranking.value.matches
+                                    %td
+                                        = ranking.value.win_loss_ratio.round(3)
+                                    %td
+                                        = ranking.value.wins
+                                    %td
+                                        = ranking.value.losses
+                                    %td
+                                        = ranking.value.forfeits
+                                    %td
+                                        = avatar_for(ranking.value.user, 16, glow: true)
+                                        = link_to_user(ranking.value.user)
             = paginate @rankings


### PR DESCRIPTION
If not enough ranked matches exist, the page will be empty like the Stats page.